### PR TITLE
Spurious key-unpressed detection

### DIFF
--- a/pew.py
+++ b/pew.py
@@ -66,7 +66,7 @@ def keys():
     global _last_keys, _keys
 
     now = time.ticks_ms()
-    if time.ticks_diff(now, _last_keys) < 10:
+    if time.ticks_diff(now, _last_keys) < 20:
         return _keys
     _last_keys = now
 


### PR DESCRIPTION
The current MicroPython implementation of `pew.keys()` for PewPew Lite 4.x under some circumstances erroneously detects keys as temporarily unpressed when they have actually been pressed for the whole time. I assume the same is true of the CircuitPython implementation, but cannot test because I don’t have a Feather that runs a current version of CircuitPython.

This hurts when a program initiates action A on a key press, then waits until all keys are up, then initiates action B on the next key press – the incorrect detection means that sometimes a single key press will trigger both A and B.

**Steps to reproduce:** Continuously keep at least one button pressed, and during that time repeatedly issue ``pew.keys(); time.sleep_ms(11); pew.keys(); time.sleep_ms(20); pew.keys()`` on the REPL.

**Actual result:** Occasionally, the middle reading will come up as zero, while the first and last are correct.

**Expected result:** All three readings should come up equal and nonzero.

The reason is that, as far as I understand the data sheet, the HT16K33 scans the keys (as well as the LEDs) with a period of 9.504 ms and sets a bit in the key data when a key has been detected as pressed in *two* consecutive scans (for debouncing). This means that with the current dead time of 10 ms during which cached data is returned rather than asking the HT16K33 for new data, it can occur that a key has only been scanned once between the last read that reset the bit and the new read and therefore its bit is still unset. The dead time needs to be increased to at least 20 ms.

This is achieved by the attached commit. I suggest an equivalent change in [pew-pewpewlite-4.x](https://github.com/pewpew-game/pew-pewpewlite-4.x/blob/900bcb50c19b2ced1174ac51d809986160aebece/pew.py#L74) (can submit a PR if desired – I’m not sure if I have push access there).